### PR TITLE
[WIP] nzxt-rgb-fan-controller: add new driver

### DIFF
--- a/Kbuild
+++ b/Kbuild
@@ -1,1 +1,1 @@
-obj-m := nzxt-kraken2.o nzxt-grid3.o nzxt-kraken3.o
+obj-m := nzxt-kraken2.o nzxt-grid3.o nzxt-kraken3.o nzxt-rgb-fan-controller.o

--- a/docs/nzxt-rgb-fan-controller.rst
+++ b/docs/nzxt-rgb-fan-controller.rst
@@ -1,0 +1,56 @@
+.. SPDX-License-Identifier: GPL-2.0-or-later
+
+Kernel driver nzxt-rgb-fan-controller
+=====================================
+
+Supported devices:
+
+- NZXT RGB & Fan controller
+
+Probably supported, but not yet tested:
+
+- NZXT Smart Device v2
+
+Description
+-----------
+
+This driver implements monitoring and control of fans plugged into the device.
+Besides typical speed monitoring and PWM duty cycle control, voltage and current
+is reported for every fan.
+
+The device also has two connectors for RGB LEDs; support for them isn't
+implemented.
+
+Also, the device has a noise sensor, but the sensor seems to be completely
+useless (and very imprecise), so support for it isn't implemented too.
+
+Usage Notes
+-----------
+
+The device should be autodetected, and the driver should load automatically.
+
+If fans are plugged in/unplugged while the system is powered on, the driver
+must be reloaded to detect configuration changes; otherwise, new fans can't
+be controlled (`pwm*` changes will be ignored). It is necessary because the
+device has a dedicated "detect fans" command, and currently, it is executed only
+during initialization. Speed, voltage, current monitoring will work even without
+reload.
+
+Sysfs entries
+-------------
+
+=======================	========================================================
+fan[1-3]_input		Fan speed monitoring (in rpm).
+curr[1-3]_input		Current supplied to the fan (in milliamperes).
+in[0-2]_input		Voltage supplied to the fan (in millivolts).
+pwm[1-3]		Controls fan speed: PWM duty cycle for PWM-controlled
+			fans, voltage for other fans. Voltage can be changed in
+			9-12 V range, but the value of the sysfs attribute is
+			always in 0-255 range (1 = 9V, 255 = 12V). Setting the
+			attribute to 0 turns off the fan completely.
+pwm[1-3]_enable		Read-only, 1 if the fan was detected, 0 otherwise.
+pwm[1-3]_mode		Read-only, 1 for PWM-controlled fans, 0 for other fans
+			(or if no fan connected).
+update_interval		The interval at which all inputs are updated (in
+			milliseconds). The default is 1000ms. Minimum is 250ms.
+=======================	========================================================

--- a/nzxt-rgb-fan-controller.c
+++ b/nzxt-rgb-fan-controller.c
@@ -1,0 +1,560 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+/*
+ *  Copyright (c) 2021 Aleksandr Mezin
+ */
+
+#include <linux/completion.h>
+#include <linux/hid.h>
+#include <linux/hwmon.h>
+#include <linux/module.h>
+#include <asm/byteorder.h>
+#include <asm/unaligned.h>
+
+/*
+ * The device has only 3 fan channels/connectors. But all HID reports have
+ * space reserved for up to 8 channels.
+ */
+#define FAN_CHANNELS 3
+#define FAN_CHANNELS_MAX 8
+
+#define UPDATE_INTERVAL_PRECISION_MS 250
+#define UPDATE_INTERVAL_DEFAULT_MS 1000
+#define INITIAL_REPORT_TIMEOUT_MS 1000
+
+enum {
+	INPUT_REPORT_ID_FAN_STATUS = 0x67,
+};
+
+enum {
+	FAN_STATUS_REPORT_SPEED = 0x02,
+	FAN_STATUS_REPORT_VOLTAGE = 0x04,
+};
+
+enum {
+	FAN_TYPE_NONE = 0,
+	FAN_TYPE_DC = 1,
+	FAN_TYPE_PWM = 2,
+};
+
+struct fan_status_report {
+	/* report_id should be INPUT_REPORT_ID_STATUS = 0x67 */
+	uint8_t report_id;
+	/* FAN_STATUS_REPORT_SPEED = 0x02 or FAN_STATUS_REPORT_VOLTAGE = 0x04 */
+	uint8_t type;
+	/* Some configuration data? Stays the same after fan speed changes,
+	 * changes in fan configuration, reboots and driver reloads.
+	 * Byte 12 seems to be the number of fan channels, but I am not sure.
+	 */
+	uint8_t unknown1[14];
+	/* Fan type as detected by the device. See FAN_TYPE_* enum. */
+	uint8_t fan_type[FAN_CHANNELS_MAX];
+
+	union {
+		/* When type == FAN_STATUS_REPORT_SPEED */
+		struct {
+			/* Fan speed, in RPM. Zero for channels without fans connected. */
+			__le16 fan_rpm[FAN_CHANNELS_MAX];
+			/* Fan duty cycle, in percent. Non-zero even for channels without fans connected. */
+			uint8_t duty_percent[FAN_CHANNELS_MAX];
+			/* Exactly the same values as duty_percent[], non-zero for disconnected fans too. */
+			uint8_t duty_percent_dup[FAN_CHANNELS_MAX];
+			/* "Case Noise" in db */
+			uint8_t noise_db;
+		} __packed fan_speed;
+		/* When type == FAN_STATUS_REPORT_VOLTAGE */
+		struct {
+			/* Voltage, in millivolts. Non-zero even when fan is not connected */
+			__le16 fan_in[FAN_CHANNELS_MAX];
+			/* Current, in milliamperes. Near-zero when disconnected */
+			__le16 fan_current[FAN_CHANNELS_MAX];
+		} __packed fan_voltage;
+	} __packed;
+} __packed;
+
+#define OUTPUT_REPORT_SIZE 64
+
+enum {
+	OUTPUT_REPORT_ID_INIT_COMMAND = 0x60,
+	OUTPUT_REPORT_ID_SET_FAN_SPEED = 0x62,
+};
+
+enum {
+	INIT_COMMAND_SET_UPDATE_INTERVAL = 0x02,
+	INIT_COMMAND_DETECT_FANS = 0x03,
+};
+
+struct set_fan_speed_report {
+	/* report_id should be OUTPUT_REPORT_ID_SET_FAN_SPEED = 0x62 */
+	uint8_t report_id;
+	/* Should be 0x01 */
+	uint8_t magic;
+	/* To change fan speed on i-th channel, set i-th bit here */
+	uint8_t channel_bit_mask;
+	/* Fan duty cycle/target speed in percent */
+	uint8_t duty_percent[FAN_CHANNELS_MAX];
+} __packed;
+
+struct fan_channel_status {
+	uint8_t type;
+	uint8_t duty_percent;
+	uint16_t rpm;
+	uint16_t in;
+	uint16_t curr;
+};
+
+struct drvdata {
+	struct hid_device *hid;
+	struct device *hwmon;
+	struct completion status_received;
+	struct fan_channel_status fan[FAN_CHANNELS];
+	long update_interval;
+};
+
+static long scale_value(long val, long orig_max, long new_max)
+{
+	if (val <= 0)
+		return 0;
+
+	if (val >= orig_max)
+		return new_max;
+
+	val *= new_max;
+
+	if ((val % orig_max) * 2 >= orig_max)
+		return val / orig_max + 1;
+	else
+		return val / orig_max;
+}
+
+static void handle_fan_status_report(struct drvdata *drvdata, void *data,
+				     int size)
+{
+	struct fan_status_report *report = data;
+	int i;
+
+	if (size < sizeof(struct fan_status_report))
+		return;
+
+	switch (report->type) {
+	case FAN_STATUS_REPORT_SPEED:
+		for (i = 0; i < FAN_CHANNELS; i++) {
+			struct fan_channel_status *fan = &drvdata->fan[i];
+
+			fan->type = report->fan_type[i];
+			fan->rpm = get_unaligned_le16(
+				&report->fan_speed.fan_rpm[i]);
+			fan->duty_percent = report->fan_speed.duty_percent[i];
+		}
+
+		if (!completion_done(&drvdata->status_received))
+			complete_all(&drvdata->status_received);
+
+		return;
+	case FAN_STATUS_REPORT_VOLTAGE:
+		for (i = 0; i < FAN_CHANNELS; i++) {
+			struct fan_channel_status *fan = &drvdata->fan[i];
+
+			fan->type = report->fan_type[i];
+			fan->in = get_unaligned_le16(
+				&report->fan_voltage.fan_in[i]);
+			fan->curr = get_unaligned_le16(
+				&report->fan_voltage.fan_current[i]);
+		}
+		return;
+	default:
+		return;
+	}
+}
+
+static umode_t hwmon_is_visible(const void *data, enum hwmon_sensor_types type,
+				u32 attr, int channel)
+{
+	switch (type) {
+	case hwmon_pwm:
+		switch (attr) {
+		case hwmon_pwm_input:
+		case hwmon_pwm_enable:
+			return 0644;
+
+		default:
+			return 0444;
+		}
+
+	case hwmon_chip:
+		switch (attr) {
+		case hwmon_chip_update_interval:
+			return 0644;
+
+		default:
+			return 0444;
+		}
+
+	default:
+		return 0444;
+	}
+}
+
+static int hwmon_read(struct device *dev, enum hwmon_sensor_types type,
+		      u32 attr, int channel, long *val)
+{
+	struct drvdata *drvdata = dev_get_drvdata(dev);
+	struct fan_channel_status *fan;
+
+	if (type == hwmon_chip) {
+		switch (attr) {
+		case hwmon_chip_update_interval:
+			*val = drvdata->update_interval;
+			return 0;
+
+		default:
+			return -EINVAL;
+		}
+	}
+
+	if (channel < 0 || channel >= FAN_CHANNELS)
+		return -EINVAL;
+
+	fan = &drvdata->fan[channel];
+
+	switch (type) {
+	case hwmon_fan:
+		switch (attr) {
+		case hwmon_fan_input:
+			*val = fan->rpm;
+			return 0;
+
+		default:
+			return -EINVAL;
+		}
+
+	case hwmon_pwm:
+		switch (attr) {
+		case hwmon_pwm_enable:
+			*val = fan->type != FAN_TYPE_NONE;
+			return 0;
+
+		case hwmon_pwm_mode:
+			*val = fan->type == FAN_TYPE_PWM;
+			return 0;
+
+		case hwmon_pwm_input:
+			*val = scale_value(fan->duty_percent, 100, 255);
+			return 0;
+
+		default:
+			return -EINVAL;
+		}
+
+	case hwmon_in:
+		switch (attr) {
+		case hwmon_in_input:
+			*val = fan->in;
+			return 0;
+
+		default:
+			return -EINVAL;
+		}
+
+	case hwmon_curr:
+		switch (attr) {
+		case hwmon_curr_input:
+			*val = fan->curr;
+			return 0;
+
+		default:
+			return -EINVAL;
+		}
+
+	default:
+		return -EINVAL;
+	}
+}
+
+static int send_output_report(struct hid_device *hdev, const void *data,
+			      size_t data_size)
+{
+	void *buffer;
+	int ret;
+
+	if (data_size > OUTPUT_REPORT_SIZE)
+		return -EINVAL;
+
+	buffer = kzalloc(OUTPUT_REPORT_SIZE, GFP_KERNEL);
+
+	if (!buffer)
+		return -ENOMEM;
+
+	memcpy(buffer, data, data_size);
+	ret = hid_hw_output_report(hdev, buffer, OUTPUT_REPORT_SIZE);
+	kfree(buffer);
+	return ret < 0 ? ret : 0;
+}
+
+static int set_pwm(struct drvdata *drvdata, int channel, long val)
+{
+	int ret;
+	uint8_t duty_percent = scale_value(val, 255, 100);
+
+	struct set_fan_speed_report report = {
+		.report_id = OUTPUT_REPORT_ID_SET_FAN_SPEED,
+		.magic = 1,
+		.channel_bit_mask = 1 << channel
+	};
+
+	report.duty_percent[channel] = duty_percent;
+	ret = send_output_report(drvdata->hid, &report, sizeof(report));
+
+	if (ret == 0) {
+		/* pwmconfig and fancontrol scripts expect pwm writes to take
+		 * effect immediately (i. e. read from pwm* sysfs should return
+		 * the value written into it). The device seems to always
+		 * accept pwm values - even when there is no fan connected - so
+		 * update pwm status without waiting for a report, to make
+		 * pwmconfig and fancontrol happy.
+		 *
+		 * This avoids "fan stuck" messages from pwmconfig, and
+		 * fancontrol setting fan speed to 100% during shutdown.
+		 */
+		drvdata->fan[channel].duty_percent = duty_percent;
+	}
+
+	return ret;
+}
+
+static int set_pwm_enable(struct drvdata *drvdata, int channel, long val)
+{
+	/* Workaround for fancontrol/pwmconfig trying to write to pwm*_enable
+	 * even if it already is 1.
+	 */
+
+	struct fan_channel_status *fan = &drvdata->fan[channel];
+	long expected_val = fan->type != FAN_TYPE_NONE;
+
+	return (val == expected_val) ? 0 : -ENOTSUPP;
+}
+
+static int set_update_interval(struct drvdata *drvdata, long val)
+{
+	uint8_t val_transformed =
+		max(val / UPDATE_INTERVAL_PRECISION_MS, 1L) - 1;
+	uint8_t report[] = {
+		OUTPUT_REPORT_ID_INIT_COMMAND,
+		INIT_COMMAND_SET_UPDATE_INTERVAL,
+		0x01,
+		0xe8,
+		val_transformed,
+		0x01,
+		0xe8,
+		val_transformed,
+	};
+
+	int ret;
+
+	ret = send_output_report(drvdata->hid, report, sizeof(report));
+	if (ret)
+		return ret;
+
+	drvdata->update_interval =
+		(val_transformed + 1) * UPDATE_INTERVAL_PRECISION_MS;
+	return 0;
+}
+
+static int detect_fans(struct hid_device *hdev)
+{
+	uint8_t report[] = {
+		OUTPUT_REPORT_ID_INIT_COMMAND,
+		INIT_COMMAND_DETECT_FANS,
+	};
+
+	return send_output_report(hdev, report, sizeof(report));
+}
+
+static int init_device(struct drvdata *drvdata, long update_interval)
+{
+	int ret;
+
+	ret = detect_fans(drvdata->hid);
+	if (ret)
+		return ret;
+
+	reinit_completion(&drvdata->status_received);
+
+	ret = set_update_interval(drvdata, 0);
+	if (ret)
+		return ret;
+
+	if (!wait_for_completion_timeout(&drvdata->status_received,
+					 INITIAL_REPORT_TIMEOUT_MS))
+		return -ETIMEDOUT;
+
+	return set_update_interval(drvdata, update_interval);
+}
+
+static int hwmon_write(struct device *dev, enum hwmon_sensor_types type,
+		       u32 attr, int channel, long val)
+{
+	struct drvdata *drvdata = dev_get_drvdata(dev);
+
+	switch (type) {
+	case hwmon_pwm:
+		if (channel < 0 || channel >= FAN_CHANNELS)
+			return -EINVAL;
+
+		switch (attr) {
+		case hwmon_pwm_enable:
+			return set_pwm_enable(drvdata, channel, val);
+
+		case hwmon_pwm_input:
+			return set_pwm(drvdata, channel, val);
+
+		default:
+			return -EINVAL;
+		}
+
+	case hwmon_chip:
+		switch (attr) {
+		case hwmon_chip_update_interval:
+			return set_update_interval(drvdata, val);
+
+		default:
+			return -EINVAL;
+		}
+
+	default:
+		return -EINVAL;
+	}
+}
+
+static const struct hwmon_ops hwmon_ops = {
+	.is_visible = hwmon_is_visible,
+	.read = hwmon_read,
+	.write = hwmon_write,
+};
+
+static const struct hwmon_channel_info *channel_info[] = {
+	HWMON_CHANNEL_INFO(fan, HWMON_F_INPUT, HWMON_F_INPUT, HWMON_F_INPUT),
+	HWMON_CHANNEL_INFO(pwm,
+			   HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE,
+			   HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE,
+			   HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE),
+	HWMON_CHANNEL_INFO(in, HWMON_I_INPUT, HWMON_I_INPUT, HWMON_I_INPUT),
+	HWMON_CHANNEL_INFO(curr, HWMON_C_INPUT, HWMON_C_INPUT, HWMON_C_INPUT),
+	HWMON_CHANNEL_INFO(chip, HWMON_C_UPDATE_INTERVAL),
+	NULL
+};
+
+static const struct hwmon_chip_info chip_info = {
+	.ops = &hwmon_ops,
+	.info = channel_info,
+};
+
+static int hid_raw_event(struct hid_device *hdev, struct hid_report *report,
+			 u8 *data, int size)
+{
+	struct drvdata *drvdata = hid_get_drvdata(hdev);
+	uint8_t report_id = *data;
+
+	if (report_id == INPUT_REPORT_ID_FAN_STATUS)
+		handle_fan_status_report(drvdata, data, size);
+
+	return 0;
+}
+
+static int hid_reset_resume(struct hid_device *hdev)
+{
+	struct drvdata *drvdata = hid_get_drvdata(hdev);
+
+	return init_device(drvdata, drvdata->update_interval);
+}
+
+static int hid_probe(struct hid_device *hdev, const struct hid_device_id *id)
+{
+	struct drvdata *drvdata;
+	int ret;
+
+	drvdata = devm_kzalloc(&hdev->dev, sizeof(struct drvdata), GFP_KERNEL);
+	if (!drvdata)
+		return -ENOMEM;
+
+	drvdata->hid = hdev;
+	hid_set_drvdata(hdev, drvdata);
+	init_completion(&drvdata->status_received);
+
+	ret = hid_parse(hdev);
+	if (ret)
+		return ret;
+
+	ret = hid_hw_start(hdev, HID_CONNECT_HIDRAW);
+	if (ret)
+		return ret;
+
+	ret = hid_hw_open(hdev);
+	if (ret)
+		goto out_hw_stop;
+
+	hid_device_io_start(hdev);
+
+	init_device(drvdata, UPDATE_INTERVAL_DEFAULT_MS);
+
+	drvdata->hwmon =
+		hwmon_device_register_with_info(&hdev->dev,
+						"nzxt_rgb_fan_controller",
+						drvdata, &chip_info, NULL);
+	if (IS_ERR(drvdata->hwmon)) {
+		ret = PTR_ERR(drvdata->hwmon);
+		goto out_hw_close;
+	}
+
+	return 0;
+
+out_hw_close:
+	hid_hw_close(hdev);
+
+out_hw_stop:
+	hid_hw_stop(hdev);
+	return ret;
+}
+
+static void hid_remove(struct hid_device *hdev)
+{
+	struct drvdata *drvdata = hid_get_drvdata(hdev);
+
+	hwmon_device_unregister(drvdata->hwmon);
+
+	hid_hw_close(hdev);
+	hid_hw_stop(hdev);
+}
+
+static const struct hid_device_id hid_id_table[] = {
+	{ HID_USB_DEVICE(0x1e71, 0x2009) },
+	{},
+};
+
+static struct hid_driver hid_driver = {
+	.name = "nzxt_rgb_fan_controller",
+	.id_table = hid_id_table,
+	.probe = hid_probe,
+	.remove = hid_remove,
+	.raw_event = hid_raw_event,
+#ifdef CONFIG_PM
+	.reset_resume = hid_reset_resume,
+#endif
+};
+
+static int __init nzxt_rgb_fan_controller_init(void)
+{
+	return hid_register_driver(&hid_driver);
+}
+
+static void __exit nzxt_rgb_fan_controller_exit(void)
+{
+	hid_unregister_driver(&hid_driver);
+}
+
+MODULE_DEVICE_TABLE(hid, hid_id_table);
+MODULE_AUTHOR("Aleksandr Mezin <mezin.alexander@gmail.com>");
+MODULE_DESCRIPTION("Driver for NZXT RGB & Fan controller");
+MODULE_LICENSE("GPL");
+
+late_initcall(nzxt_rgb_fan_controller_init);
+module_exit(nzxt_rgb_fan_controller_exit);

--- a/nzxt-rgb-fan-controller.c
+++ b/nzxt-rgb-fan-controller.c
@@ -1,12 +1,24 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 /*
- *  Copyright (c) 2021 Aleksandr Mezin
+ * Reverse-engineered NZXT RGB & Fan Controller/Smart Device v2 driver.
+ *
+ * Copyright (c) 2021 Aleksandr Mezin
  */
 
-#include <linux/completion.h>
+#include <linux/version.h>
+
 #include <linux/hid.h>
 #include <linux/hwmon.h>
+#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
+#include <linux/kernel.h>
+#else
+#include <linux/math.h>
+#endif
 #include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/spinlock.h>
+#include <linux/wait.h>
+
 #include <asm/byteorder.h>
 #include <asm/unaligned.h>
 
@@ -17,11 +29,10 @@
 #define FAN_CHANNELS 3
 #define FAN_CHANNELS_MAX 8
 
-#define UPDATE_INTERVAL_PRECISION_MS 250
 #define UPDATE_INTERVAL_DEFAULT_MS 1000
-#define INITIAL_REPORT_TIMEOUT_MS 1000
 
 enum {
+	INPUT_REPORT_ID_FAN_CONFIG = 0x61,
 	INPUT_REPORT_ID_FAN_STATUS = 0x67,
 };
 
@@ -36,36 +47,78 @@ enum {
 	FAN_TYPE_PWM = 2,
 };
 
-struct fan_status_report {
-	/* report_id should be INPUT_REPORT_ID_STATUS = 0x67 */
-	uint8_t report_id;
-	/* FAN_STATUS_REPORT_SPEED = 0x02 or FAN_STATUS_REPORT_VOLTAGE = 0x04 */
-	uint8_t type;
-	/* Some configuration data? Stays the same after fan speed changes,
+struct unknown_static_data {
+	/*
+	 * Some configuration data? Stays the same after fan speed changes,
 	 * changes in fan configuration, reboots and driver reloads.
+	 *
+	 * The same data in multiple report types.
+	 *
 	 * Byte 12 seems to be the number of fan channels, but I am not sure.
 	 */
-	uint8_t unknown1[14];
+	u8 unknown1[14];
+} __packed;
+
+/*
+ * The device sends this input report in response to "detect fans" command:
+ * a 2-byte output report { 0x60, 0x03 }.
+ */
+struct fan_config_report {
+	/* report_id should be INPUT_REPORT_ID_FAN_CONFIG = 0x61 */
+	u8 report_id;
+	/* Always 0x03 */
+	u8 magic;
+	struct unknown_static_data unknown_data;
 	/* Fan type as detected by the device. See FAN_TYPE_* enum. */
-	uint8_t fan_type[FAN_CHANNELS_MAX];
+	u8 fan_type[FAN_CHANNELS_MAX];
+} __packed;
+
+/*
+ * The device sends these reports at a fixed interval (update interval) -
+ * one report with type = FAN_STATUS_REPORT_SPEED, and one report with type =
+ * FAN_STATUS_REPORT_VOLTAGE per update interval.
+ */
+struct fan_status_report {
+	/* report_id should be INPUT_REPORT_ID_STATUS = 0x67 */
+	u8 report_id;
+	/* FAN_STATUS_REPORT_SPEED = 0x02 or FAN_STATUS_REPORT_VOLTAGE = 0x04 */
+	u8 type;
+	struct unknown_static_data unknown_data;
+	/* Fan type as detected by the device. See FAN_TYPE_* enum. */
+	u8 fan_type[FAN_CHANNELS_MAX];
 
 	union {
 		/* When type == FAN_STATUS_REPORT_SPEED */
 		struct {
-			/* Fan speed, in RPM. Zero for channels without fans connected. */
+			/*
+			 * Fan speed, in RPM. Zero for channels without fans
+			 * connected.
+			 */
 			__le16 fan_rpm[FAN_CHANNELS_MAX];
-			/* Fan duty cycle, in percent. Non-zero even for channels without fans connected. */
-			uint8_t duty_percent[FAN_CHANNELS_MAX];
-			/* Exactly the same values as duty_percent[], non-zero for disconnected fans too. */
-			uint8_t duty_percent_dup[FAN_CHANNELS_MAX];
+			/*
+			 * Fan duty cycle, in percent. Non-zero even for
+			 * channels without fans connected.
+			 */
+			u8 duty_percent[FAN_CHANNELS_MAX];
+			/*
+			 * Exactly the same values as duty_percent[], non-zero
+			 * for disconnected fans too.
+			 */
+			u8 duty_percent_dup[FAN_CHANNELS_MAX];
 			/* "Case Noise" in db */
-			uint8_t noise_db;
+			u8 noise_db;
 		} __packed fan_speed;
 		/* When type == FAN_STATUS_REPORT_VOLTAGE */
 		struct {
-			/* Voltage, in millivolts. Non-zero even when fan is not connected */
+			/*
+			 * Voltage, in millivolts. Non-zero even when fan is
+			 * not connected.
+			 */
 			__le16 fan_in[FAN_CHANNELS_MAX];
-			/* Current, in milliamperes. Near-zero when disconnected */
+			/*
+			 * Current, in milliamperes. Near-zero when
+			 * disconnected.
+			 */
 			__le16 fan_current[FAN_CHANNELS_MAX];
 		} __packed fan_voltage;
 	} __packed;
@@ -83,51 +136,97 @@ enum {
 	INIT_COMMAND_DETECT_FANS = 0x03,
 };
 
+/*
+ * This output report sets pwm duty cycle/target fan speed for one or more
+ * channels.
+ */
 struct set_fan_speed_report {
 	/* report_id should be OUTPUT_REPORT_ID_SET_FAN_SPEED = 0x62 */
-	uint8_t report_id;
+	u8 report_id;
 	/* Should be 0x01 */
-	uint8_t magic;
+	u8 magic;
 	/* To change fan speed on i-th channel, set i-th bit here */
-	uint8_t channel_bit_mask;
-	/* Fan duty cycle/target speed in percent */
-	uint8_t duty_percent[FAN_CHANNELS_MAX];
+	u8 channel_bit_mask;
+	/*
+	 * Fan duty cycle/target speed in percent. For voltage-controlled fans,
+	 * the minimal voltage (duty_percent = 1) is about 9V.
+	 * Setting duty_percent to 0 (if the channel is selected in
+	 * channel_bit_mask) turns off the fan completely (regardless of the
+	 * control mode).
+	 */
+	u8 duty_percent[FAN_CHANNELS_MAX];
 } __packed;
-
-struct fan_channel_status {
-	uint8_t type;
-	uint8_t duty_percent;
-	uint16_t rpm;
-	uint16_t in;
-	uint16_t curr;
-};
 
 struct drvdata {
 	struct hid_device *hid;
 	struct device *hwmon;
-	struct completion status_received;
-	struct fan_channel_status fan[FAN_CHANNELS];
+
+	u8 fan_duty_percent[FAN_CHANNELS];
+	u16 fan_rpm[FAN_CHANNELS];
+	bool pwm_status_received;
+
+	u16 fan_in[FAN_CHANNELS];
+	u16 fan_curr[FAN_CHANNELS];
+	bool voltage_status_received;
+
+	u8 fan_type[FAN_CHANNELS];
+	bool fan_config_received;
+
+	/*
+	 * wq is used to wait for *_received flags to become true.
+	 * All accesses to *_received flags and fan_* arrays are performed with
+	 * wq.lock held.
+	 */
+	wait_queue_head_t wq;
+	/*
+	 * mutex is used to:
+	 * 1) Prevent concurrent conflicting changes to update interval and pwm
+	 * values (after sending an output hid report, the corresponding field
+	 * in drvdata must be updated, and only then new output reports can be
+	 * sent).
+	 * 2) Synchronize access to output_buffer (well, the buffer is here,
+	 * because synchronization is necessary anyway - so why not get rid of
+	 * a kmalloc?).
+	 */
+	struct mutex mutex;
 	long update_interval;
+	u8 output_buffer[OUTPUT_REPORT_SIZE];
 };
 
-static long scale_value(long val, long orig_max, long new_max)
+static long scale_pwm_value(long val, long orig_max, long new_max)
 {
 	if (val <= 0)
 		return 0;
 
-	if (val >= orig_max)
-		return new_max;
-
-	val *= new_max;
-
-	if ((val % orig_max) * 2 >= orig_max)
-		return val / orig_max + 1;
-	else
-		return val / orig_max;
+	/*
+	 * Positive values should not become zero: 0 completely turns off the
+	 * fan.
+	 */
+	return max(1L, DIV_ROUND_CLOSEST(min(val, orig_max) * new_max, orig_max));
 }
 
-static void handle_fan_status_report(struct drvdata *drvdata, void *data,
-				     int size)
+static void handle_fan_config_report(struct drvdata *drvdata, void *data, int size)
+{
+	struct fan_config_report *report = data;
+	int i;
+
+	if (size < sizeof(struct fan_config_report))
+		return;
+
+	if (report->magic != 0x03)
+		return;
+
+	spin_lock(&drvdata->wq.lock);
+
+	for (i = 0; i < FAN_CHANNELS; i++)
+		drvdata->fan_type[i] = report->fan_type[i];
+
+	drvdata->fan_config_received = true;
+	wake_up_all_locked(&drvdata->wq);
+	spin_unlock(&drvdata->wq.lock);
+}
+
+static void handle_fan_status_report(struct drvdata *drvdata, void *data, int size)
 {
 	struct fan_status_report *report = data;
 	int i;
@@ -135,35 +234,62 @@ static void handle_fan_status_report(struct drvdata *drvdata, void *data,
 	if (size < sizeof(struct fan_status_report))
 		return;
 
+	spin_lock(&drvdata->wq.lock);
+
+	/*
+	 * The device sends INPUT_REPORT_ID_FAN_CONFIG = 0x61 report in response
+	 * to "detect fans" command. Only accept other data after getting 0x61,
+	 * to make sure that fan detection is complete and the data is not stale.
+	 */
+	if (!drvdata->fan_config_received) {
+		spin_unlock(&drvdata->wq.lock);
+		return;
+	}
+
+	for (i = 0; i < FAN_CHANNELS; i++) {
+		if (drvdata->fan_type[i] == report->fan_type[i])
+			continue;
+
+		/*
+		 * This should not happen (if my expectations about the device
+		 * are true).
+		 *
+		 * Even if the userspace sends fan detect command through
+		 * hidraw, fan config report should arrive first.
+		 */
+		hid_warn_once(drvdata->hid,
+			      "Fan %d type changed unexpectedly from %d to %d",
+			      i, drvdata->fan_type[i], report->fan_type[i]);
+		drvdata->fan_type[i] = report->fan_type[i];
+	}
+
 	switch (report->type) {
 	case FAN_STATUS_REPORT_SPEED:
 		for (i = 0; i < FAN_CHANNELS; i++) {
-			struct fan_channel_status *fan = &drvdata->fan[i];
-
-			fan->type = report->fan_type[i];
-			fan->rpm = get_unaligned_le16(
-				&report->fan_speed.fan_rpm[i]);
-			fan->duty_percent = report->fan_speed.duty_percent[i];
+			drvdata->fan_rpm[i] =
+				get_unaligned_le16(&report->fan_speed.fan_rpm[i]);
+			drvdata->fan_duty_percent[i] =
+				report->fan_speed.duty_percent[i];
 		}
 
-		if (!completion_done(&drvdata->status_received))
-			complete_all(&drvdata->status_received);
+		drvdata->pwm_status_received = true;
+		wake_up_all_locked(&drvdata->wq);
+		break;
 
-		return;
 	case FAN_STATUS_REPORT_VOLTAGE:
 		for (i = 0; i < FAN_CHANNELS; i++) {
-			struct fan_channel_status *fan = &drvdata->fan[i];
-
-			fan->type = report->fan_type[i];
-			fan->in = get_unaligned_le16(
-				&report->fan_voltage.fan_in[i]);
-			fan->curr = get_unaligned_le16(
-				&report->fan_voltage.fan_current[i]);
+			drvdata->fan_in[i] =
+				get_unaligned_le16(&report->fan_voltage.fan_in[i]);
+			drvdata->fan_curr[i] =
+				get_unaligned_le16(&report->fan_voltage.fan_current[i]);
 		}
-		return;
-	default:
-		return;
+
+		drvdata->voltage_status_received = true;
+		wake_up_all_locked(&drvdata->wq);
+		break;
 	}
+
+	spin_unlock(&drvdata->wq.lock);
 }
 
 static umode_t hwmon_is_visible(const void *data, enum hwmon_sensor_types type,
@@ -198,12 +324,12 @@ static int hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 		      u32 attr, int channel, long *val)
 {
 	struct drvdata *drvdata = dev_get_drvdata(dev);
-	struct fan_channel_status *fan;
+	int res = -EINVAL;
 
 	if (type == hwmon_chip) {
 		switch (attr) {
 		case hwmon_chip_update_interval:
-			*val = drvdata->update_interval;
+			*val = READ_ONCE(drvdata->update_interval);
 			return 0;
 
 		default:
@@ -211,89 +337,115 @@ static int hwmon_read(struct device *dev, enum hwmon_sensor_types type,
 		}
 	}
 
-	if (channel < 0 || channel >= FAN_CHANNELS)
-		return -EINVAL;
-
-	fan = &drvdata->fan[channel];
+	spin_lock_irq(&drvdata->wq.lock);
 
 	switch (type) {
-	case hwmon_fan:
-		switch (attr) {
-		case hwmon_fan_input:
-			*val = fan->rpm;
-			return 0;
-
-		default:
-			return -EINVAL;
-		}
-
 	case hwmon_pwm:
+		/*
+		 * fancontrol:
+		 * 1) remembers pwm* values when it starts
+		 * 2) needs pwm*_enable to be 1 on controlled fans
+		 * So make sure we have correct data before allowing pwm* reads.
+		 */
 		switch (attr) {
 		case hwmon_pwm_enable:
-			*val = fan->type != FAN_TYPE_NONE;
-			return 0;
+			res = wait_event_interruptible_locked_irq(drvdata->wq,
+								  drvdata->fan_config_received);
+
+			if (res == 0)
+				*val = drvdata->fan_type[channel] != FAN_TYPE_NONE;
+
+			break;
 
 		case hwmon_pwm_mode:
-			*val = fan->type == FAN_TYPE_PWM;
-			return 0;
+			res = wait_event_interruptible_locked_irq(drvdata->wq,
+								  drvdata->fan_config_received);
+
+			if (res == 0)
+				*val = drvdata->fan_type[channel] == FAN_TYPE_PWM;
+
+			break;
 
 		case hwmon_pwm_input:
-			*val = scale_value(fan->duty_percent, 100, 255);
-			return 0;
+			res = wait_event_interruptible_locked_irq(drvdata->wq,
+								  drvdata->pwm_status_received);
 
-		default:
-			return -EINVAL;
+			if (res == 0)
+				*val = scale_pwm_value(drvdata->fan_duty_percent[channel],
+						       100, 255);
+
+			break;
 		}
+		break;
+
+	case hwmon_fan:
+		/*
+		 * It's not strictly necessary to wait for *_received in the
+		 * remaining cases (fancontrol doesn't care about them). But I'm
+		 * doing it to have consistent behavior.
+		 */
+		if (attr == hwmon_fan_input) {
+			res = wait_event_interruptible_locked_irq(drvdata->wq,
+								  drvdata->pwm_status_received);
+
+			if (res == 0)
+				*val = drvdata->fan_rpm[channel];
+		}
+		break;
 
 	case hwmon_in:
-		switch (attr) {
-		case hwmon_in_input:
-			*val = fan->in;
-			return 0;
+		if (attr == hwmon_in_input) {
+			res = wait_event_interruptible_locked_irq(drvdata->wq,
+								  drvdata->voltage_status_received);
 
-		default:
-			return -EINVAL;
+			if (res == 0)
+				*val = drvdata->fan_in[channel];
 		}
+		break;
 
 	case hwmon_curr:
-		switch (attr) {
-		case hwmon_curr_input:
-			*val = fan->curr;
-			return 0;
+		if (attr == hwmon_curr_input) {
+			res = wait_event_interruptible_locked_irq(drvdata->wq,
+								  drvdata->voltage_status_received);
 
-		default:
-			return -EINVAL;
+			if (res == 0)
+				*val = drvdata->fan_curr[channel];
 		}
+		break;
 
 	default:
-		return -EINVAL;
+		break;
 	}
+
+	spin_unlock_irq(&drvdata->wq.lock);
+	return res;
 }
 
-static int send_output_report(struct hid_device *hdev, const void *data,
+static int send_output_report(struct drvdata *drvdata, const void *data,
 			      size_t data_size)
 {
-	void *buffer;
 	int ret;
 
-	if (data_size > OUTPUT_REPORT_SIZE)
+	lockdep_assert_held(&drvdata->mutex);
+
+	if (data_size > sizeof(drvdata->output_buffer))
 		return -EINVAL;
 
-	buffer = kzalloc(OUTPUT_REPORT_SIZE, GFP_KERNEL);
+	memcpy(drvdata->output_buffer, data, data_size);
 
-	if (!buffer)
-		return -ENOMEM;
+	if (data_size < sizeof(drvdata->output_buffer))
+		memset(drvdata->output_buffer + data_size, 0,
+		       sizeof(drvdata->output_buffer) - data_size);
 
-	memcpy(buffer, data, data_size);
-	ret = hid_hw_output_report(hdev, buffer, OUTPUT_REPORT_SIZE);
-	kfree(buffer);
+	ret = hid_hw_output_report(drvdata->hid, drvdata->output_buffer,
+				   sizeof(drvdata->output_buffer));
 	return ret < 0 ? ret : 0;
 }
 
 static int set_pwm(struct drvdata *drvdata, int channel, long val)
 {
 	int ret;
-	uint8_t duty_percent = scale_value(val, 255, 100);
+	u8 duty_percent = scale_pwm_value(val, 255, 100);
 
 	struct set_fan_speed_report report = {
 		.report_id = OUTPUT_REPORT_ID_SET_FAN_SPEED,
@@ -301,105 +453,155 @@ static int set_pwm(struct drvdata *drvdata, int channel, long val)
 		.channel_bit_mask = 1 << channel
 	};
 
-	report.duty_percent[channel] = duty_percent;
-	ret = send_output_report(drvdata->hid, &report, sizeof(report));
+	ret = mutex_lock_interruptible(&drvdata->mutex);
+	if (ret)
+		return ret;
 
+	report.duty_percent[channel] = duty_percent;
+	ret = send_output_report(drvdata, &report, sizeof(report));
+
+	/*
+	 * pwmconfig and fancontrol scripts expect pwm writes to take effect
+	 * immediately (i. e. read from pwm* sysfs should return the value
+	 * written into it). The device seems to always accept pwm values - even
+	 * when there is no fan connected - so update pwm status without waiting
+	 * for a report, to make pwmconfig and fancontrol happy. Worst case -
+	 * if the device didn't accept new pwm value for some reason (never seen
+	 * this in practice) - it will be reported incorrectly only until next
+	 * update. This avoids "fan stuck" messages from pwmconfig, and
+	 * fancontrol setting fan speed to 100% during shutdown.
+	 */
 	if (ret == 0) {
-		/* pwmconfig and fancontrol scripts expect pwm writes to take
-		 * effect immediately (i. e. read from pwm* sysfs should return
-		 * the value written into it). The device seems to always
-		 * accept pwm values - even when there is no fan connected - so
-		 * update pwm status without waiting for a report, to make
-		 * pwmconfig and fancontrol happy.
-		 *
-		 * This avoids "fan stuck" messages from pwmconfig, and
-		 * fancontrol setting fan speed to 100% during shutdown.
-		 */
-		drvdata->fan[channel].duty_percent = duty_percent;
+		spin_lock_bh(&drvdata->wq.lock);
+		drvdata->fan_duty_percent[channel] = duty_percent;
+		spin_unlock_bh(&drvdata->wq.lock);
 	}
+
+	mutex_unlock(&drvdata->mutex);
 
 	return ret;
 }
 
+/*
+ * Workaround for fancontrol/pwmconfig trying to write to pwm*_enable even if it
+ * already is 1.
+ */
 static int set_pwm_enable(struct drvdata *drvdata, int channel, long val)
 {
-	/* Workaround for fancontrol/pwmconfig trying to write to pwm*_enable
-	 * even if it already is 1.
-	 */
+	long expected_val;
+	int res;
 
-	struct fan_channel_status *fan = &drvdata->fan[channel];
-	long expected_val = fan->type != FAN_TYPE_NONE;
+	spin_lock_irq(&drvdata->wq.lock);
 
-	return (val == expected_val) ? 0 : -ENOTSUPP;
+	res = wait_event_interruptible_locked_irq(drvdata->wq,
+						  drvdata->fan_config_received);
+
+	if (res == 0)
+		expected_val = drvdata->fan_type[channel] != FAN_TYPE_NONE;
+
+	spin_unlock_irq(&drvdata->wq.lock);
+
+	if (res)
+		return res;
+
+	return (val == expected_val) ? 0 : -EOPNOTSUPP;
+}
+
+/*
+ * Control byte	| Actual update interval
+ * 0xff		| 65.5
+ * 0xf7		| 63.46
+ * 0x7f		| 32.74
+ * 0x3f		| 16.36
+ * 0x1f		| 8.17
+ * 0x0f		| 4.07
+ * 0x07		| 2.02
+ * 0x03		| 1.00
+ * 0x02		| 0.744
+ * 0x01		| 0.488
+ * 0x00		| 0.25
+ */
+static u8 update_interval_to_control_byte(long interval)
+{
+	if (interval <= 250)
+		return 0;
+
+	return clamp_val(1 + DIV_ROUND_CLOSEST(interval - 488, 256), 0, 255);
+}
+
+static long control_byte_to_update_interval(u8 control_byte)
+{
+	if (control_byte == 0)
+		return 250;
+
+	return 488 + (control_byte - 1) * 256;
 }
 
 static int set_update_interval(struct drvdata *drvdata, long val)
 {
-	uint8_t val_transformed =
-		max(val / UPDATE_INTERVAL_PRECISION_MS, 1L) - 1;
-	uint8_t report[] = {
+	u8 control = update_interval_to_control_byte(val);
+	u8 report[] = {
 		OUTPUT_REPORT_ID_INIT_COMMAND,
 		INIT_COMMAND_SET_UPDATE_INTERVAL,
 		0x01,
 		0xe8,
-		val_transformed,
+		control,
 		0x01,
 		0xe8,
-		val_transformed,
+		control,
 	};
-
 	int ret;
 
-	ret = send_output_report(drvdata->hid, report, sizeof(report));
-	if (ret)
-		return ret;
+	ret = send_output_report(drvdata, report, sizeof(report));
+	if (ret == 0)
+		WRITE_ONCE(drvdata->update_interval,
+			   control_byte_to_update_interval(control));
 
-	drvdata->update_interval =
-		(val_transformed + 1) * UPDATE_INTERVAL_PRECISION_MS;
-	return 0;
-}
-
-static int detect_fans(struct hid_device *hdev)
-{
-	uint8_t report[] = {
-		OUTPUT_REPORT_ID_INIT_COMMAND,
-		INIT_COMMAND_DETECT_FANS,
-	};
-
-	return send_output_report(hdev, report, sizeof(report));
+	return ret;
 }
 
 static int init_device(struct drvdata *drvdata, long update_interval)
 {
 	int ret;
+	u8 detect_fans_report[] = {
+		OUTPUT_REPORT_ID_INIT_COMMAND,
+		INIT_COMMAND_DETECT_FANS,
+	};
 
-	ret = detect_fans(drvdata->hid);
-	if (ret)
-		return ret;
+	/*
+	 * This lock is here only to avoid lockdep warning. Am I using lockdep
+	 * incorrectly?
+	 * There's (currently) no way init_device() could be called multiple
+	 * times concurrently (or concurrently with other functions that lock
+	 * the mutex).
+	 */
+	mutex_lock(&drvdata->mutex);
 
-	reinit_completion(&drvdata->status_received);
+	spin_lock_bh(&drvdata->wq.lock);
+	drvdata->fan_config_received = false;
+	drvdata->pwm_status_received = false;
+	drvdata->voltage_status_received = false;
+	spin_unlock_bh(&drvdata->wq.lock);
 
-	ret = set_update_interval(drvdata, 0);
-	if (ret)
-		return ret;
+	ret = send_output_report(drvdata, detect_fans_report,
+				 sizeof(detect_fans_report));
 
-	if (!wait_for_completion_timeout(&drvdata->status_received,
-					 INITIAL_REPORT_TIMEOUT_MS))
-		return -ETIMEDOUT;
+	if (ret == 0)
+		ret = set_update_interval(drvdata, update_interval);
 
-	return set_update_interval(drvdata, update_interval);
+	mutex_unlock(&drvdata->mutex);
+
+	return ret;
 }
 
 static int hwmon_write(struct device *dev, enum hwmon_sensor_types type,
 		       u32 attr, int channel, long val)
 {
 	struct drvdata *drvdata = dev_get_drvdata(dev);
+	int ret;
 
 	switch (type) {
 	case hwmon_pwm:
-		if (channel < 0 || channel >= FAN_CHANNELS)
-			return -EINVAL;
-
 		switch (attr) {
 		case hwmon_pwm_enable:
 			return set_pwm_enable(drvdata, channel, val);
@@ -414,7 +616,14 @@ static int hwmon_write(struct device *dev, enum hwmon_sensor_types type,
 	case hwmon_chip:
 		switch (attr) {
 		case hwmon_chip_update_interval:
-			return set_update_interval(drvdata, val);
+			ret = mutex_lock_interruptible(&drvdata->mutex);
+			if (ret)
+				return ret;
+
+			ret = set_update_interval(drvdata, val);
+
+			mutex_unlock(&drvdata->mutex);
+			return ret;
 
 		default:
 			return -EINVAL;
@@ -433,8 +642,7 @@ static const struct hwmon_ops hwmon_ops = {
 
 static const struct hwmon_channel_info *channel_info[] = {
 	HWMON_CHANNEL_INFO(fan, HWMON_F_INPUT, HWMON_F_INPUT, HWMON_F_INPUT),
-	HWMON_CHANNEL_INFO(pwm,
-			   HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE,
+	HWMON_CHANNEL_INFO(pwm, HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE,
 			   HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE,
 			   HWMON_PWM_INPUT | HWMON_PWM_MODE | HWMON_PWM_ENABLE),
 	HWMON_CHANNEL_INFO(in, HWMON_I_INPUT, HWMON_I_INPUT, HWMON_I_INPUT),
@@ -452,10 +660,17 @@ static int hid_raw_event(struct hid_device *hdev, struct hid_report *report,
 			 u8 *data, int size)
 {
 	struct drvdata *drvdata = hid_get_drvdata(hdev);
-	uint8_t report_id = *data;
+	u8 report_id = *data;
 
-	if (report_id == INPUT_REPORT_ID_FAN_STATUS)
+	switch (report_id) {
+	case INPUT_REPORT_ID_FAN_CONFIG:
+		handle_fan_config_report(drvdata, data, size);
+		break;
+
+	case INPUT_REPORT_ID_FAN_STATUS:
 		handle_fan_status_report(drvdata, data, size);
+		break;
+	}
 
 	return 0;
 }
@@ -464,7 +679,7 @@ static int hid_reset_resume(struct hid_device *hdev)
 {
 	struct drvdata *drvdata = hid_get_drvdata(hdev);
 
-	return init_device(drvdata, drvdata->update_interval);
+	return init_device(drvdata, READ_ONCE(drvdata->update_interval));
 }
 
 static int hid_probe(struct hid_device *hdev, const struct hid_device_id *id)
@@ -478,7 +693,12 @@ static int hid_probe(struct hid_device *hdev, const struct hid_device_id *id)
 
 	drvdata->hid = hdev;
 	hid_set_drvdata(hdev, drvdata);
-	init_completion(&drvdata->status_received);
+
+	init_waitqueue_head(&drvdata->wq);
+
+	mutex_init(&drvdata->mutex);
+	devm_add_action(&hdev->dev, (void (*)(void *))mutex_destroy,
+			&drvdata->mutex);
 
 	ret = hid_parse(hdev);
 	if (ret)
@@ -526,7 +746,11 @@ static void hid_remove(struct hid_device *hdev)
 }
 
 static const struct hid_device_id hid_id_table[] = {
-	{ HID_USB_DEVICE(0x1e71, 0x2009) },
+	{ HID_USB_DEVICE(0x1e71, 0x2006) }, /* NZXT Smart Device V2 */
+	{ HID_USB_DEVICE(0x1e71, 0x200d) }, /* NZXT Smart Device V2 */
+	{ HID_USB_DEVICE(0x1e71, 0x2009) }, /* NZXT RGB & Fan Controller */
+	{ HID_USB_DEVICE(0x1e71, 0x200e) }, /* NZXT RGB & Fan Controller */
+	{ HID_USB_DEVICE(0x1e71, 0x2010) }, /* NZXT RGB & Fan Controller */
 	{},
 };
 
@@ -553,8 +777,14 @@ static void __exit nzxt_rgb_fan_controller_exit(void)
 
 MODULE_DEVICE_TABLE(hid, hid_id_table);
 MODULE_AUTHOR("Aleksandr Mezin <mezin.alexander@gmail.com>");
-MODULE_DESCRIPTION("Driver for NZXT RGB & Fan controller");
+MODULE_DESCRIPTION("Driver for NZXT RGB & Fan Controller/Smart Device V2");
 MODULE_LICENSE("GPL");
 
+/*
+ * With module_init()/module_hid_driver() and the driver built into the kernel:
+ *
+ * Driver 'nzxt_rgb_fan_controller' was unable to register with bus_type 'hid'
+ * because the bus was not initialized.
+ */
 late_initcall(nzxt_rgb_fan_controller_init);
 module_exit(nzxt_rgb_fan_controller_exit);


### PR DESCRIPTION
Driver for NZXT "RGB & Fan Controller", Smart Device v2

Currently only one USB ID in id table (the device I have), and no docs.

Works with fancontrol and pwmconfig, no checkpatch.pl issues.

Though I can't verify what happens if fancontrol is enabled on boot because of this issue: https://github.com/lm-sensors/lm-sensors/issues/227 (device names change on every boot, fancontrol always fails to start)