### PR TITLE
nzxt-smart2: fix unused-function warning

### DIFF
--- a/nzxt-smart2.c
+++ b/nzxt-smart2.c
@@ -710,6 +710,8 @@ static int nzxt_smart2_hid_raw_event(struct hid_device *hdev,
 	return 0;
 }
 
+#ifdef CONFIG_PM
+
 static int nzxt_smart2_hid_reset_resume(struct hid_device *hdev)
 {
 	struct drvdata *drvdata = hid_get_drvdata(hdev);
@@ -726,6 +728,8 @@ static int nzxt_smart2_hid_reset_resume(struct hid_device *hdev)
 
 	return init_device(drvdata, drvdata->update_interval);
 }
+
+#endif
 
 static int nzxt_smart2_hid_probe(struct hid_device *hdev,
 				 const struct hid_device_id *id)


### PR DESCRIPTION
    /home/runner/work/liquidtux/liquidtux/src/nzxt-smart2.c:713:12: warning: ‘nzxt_smart2_hid_reset_resume’ defined but not used [-Wunused-function]
      713 | static int nzxt_smart2_hid_reset_resume(struct hid_device *hdev)
          |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~