### PR TITLE
nzxt-smart2: add another USB ID

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -16,6 +16,7 @@ USB_IDS = [
   { :vendor => "0x1e71", :product => "0x200d" },
   { :vendor => "0x1e71", :product => "0x2009" },
   { :vendor => "0x1e71", :product => "0x200e" },
+  { :vendor => "0x1e71", :product => "0x200f" },
   { :vendor => "0x1e71", :product => "0x2010" },
 ]
 

--- a/nzxt-smart2.c
+++ b/nzxt-smart2.c
@@ -795,6 +795,7 @@ static const struct hid_device_id nzxt_smart2_hid_id_table[] = {
 	{ HID_USB_DEVICE(0x1e71, 0x200d) }, /* NZXT Smart Device V2 */
 	{ HID_USB_DEVICE(0x1e71, 0x2009) }, /* NZXT RGB & Fan Controller */
 	{ HID_USB_DEVICE(0x1e71, 0x200e) }, /* NZXT RGB & Fan Controller */
+	{ HID_USB_DEVICE(0x1e71, 0x200f) }, /* NZXT Smart Device V2 */
 	{ HID_USB_DEVICE(0x1e71, 0x2010) }, /* NZXT RGB & Fan Controller */
 	{},
 };


### PR DESCRIPTION
It is the same device, according to liquidctl sources.

Added in https://github.com/liquidctl/liquidctl/pull/364