### PR TITLE
nzxt-kraken3: correct Z53 name initialization

### DIFF
--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -27,7 +27,7 @@ enum pwm_enable { off, manual, curve } __packed;
 
 static const char *const kraken3_device_names[] = {
 	[X53] = "x53",
-	[X53] = "z53",
+	[Z53] = "z53",
 };
 
 #define DRIVER_NAME		"nzxt_kraken3"


### PR DESCRIPTION
Just a one-line fix to correct name initialization for the Z53.

Related: #22 