### PR TITLE
Update Vagrant box to Fedora 37

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -42,6 +42,11 @@ Vagrant.configure("2") do |config|
     libvirt.cpus = CPUS
     libvirt.memory = MEMORY
 
+    # Error while creating domain: Error saving the server: Call to virDomainDefineXML failed:
+    # unsupported configuration: chardev 'spicevmc' not supported without spice graphics
+    libvirt.graphics_type = "spice"
+    libvirt.channel :type => "spicevmc", :target_name => "com.redhat.spice.0", :target_type => "virtio"
+
     libvirt.usb_controller :model => "qemu-xhci"
     libvirt.redirdev :type => "spicevmc"
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,6 +53,11 @@ Vagrant.configure("2") do |config|
     USB_IDS.each do |usb_id|
       libvirt.usb usb_id.merge :startupPolicy => "optional"
     end
+
+    if Vagrant.has_plugin?("vagrant-libvirt", "> 0.5.3")
+      libvirt.channel :type => "unix", :target_name => "org.qemu.guest_agent.0", :target_type => "virtio"
+      libvirt.qemu_use_agent = true
+    end
   end
 
   config.vm.provision "ansible" do |ansible|

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,13 +21,9 @@ USB_IDS = [
 ]
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "Fedora-Cloud-Base-Vagrant-34"
-  config.vm.box_download_checksum_type = "sha256"
+  config.vm.box = "fedora/37-cloud-base"
 
   config.vm.provider "virtualbox" do |virtualbox, override|
-    override.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-34-1.2.x86_64.vagrant-virtualbox.box"
-    override.vm.box_download_checksum = "e72d9987c61d58108910fab700e8bdf349e69d2e158037a10b07706a68446fda"
-
     virtualbox.cpus = CPUS
     virtualbox.memory = MEMORY
     virtualbox.default_nic_type = "virtio"
@@ -43,9 +39,6 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.provider "libvirt" do |libvirt, override|
-    override.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/34/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-34-1.2.x86_64.vagrant-libvirt.box"
-    override.vm.box_download_checksum = "3d9c00892253c869bffcf2e84ddd308e90d5c7a5928b3bc00e0563a4bec55849"
-
     libvirt.cpus = CPUS
     libvirt.memory = MEMORY
 


### PR DESCRIPTION
Also, be less paranoid, and trust the official Vagrant box(es), instead of hardcoding download URLs and checksums.