### PR TITLE
nzxt-kraken3: Remove the unused spinlock.h include

### DIFF
--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -15,7 +15,6 @@
 #include <linux/jiffies.h>
 #include <linux/module.h>
 #include <linux/mutex.h>
-#include <linux/spinlock.h>
 #include <asm/unaligned.h>
 
 #define USB_VENDOR_ID_NZXT		0x1e71


### PR DESCRIPTION
Was looking through the code and noticed that I didn't remove the spinlock.h include.