### PR TITLE
Makefile: fix shell errors in dkms_install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ PKGVER ?= $(shell ./gitversion.sh)
 dkms.conf: dkms.conf.in
 	sed -e "s/@PKGVER@/$(PKGVER)/" $< >$@
 
+# Generate dkms.conf again every time to avoid stale version numbers
+.PHONY: dkms.conf
+
 # https://www.gnu.org/software/make/manual/html_node/Command-Variables.html
 INSTALL := install
 INSTALL_PROGRAM := $(INSTALL)
@@ -23,10 +26,8 @@ INSTALL_DATA := $(INSTALL) -m 644
 # https://www.gnu.org/software/make/manual/html_node/Directory-Variables.html
 prefix := /usr
 
-# PACKAGE_NAME and PACKAGE_VERSION should come from dkms.conf.
-# Source dkms.conf before using INSTALL_BASE_DIR.
-dkms_install: INSTALL_BASE_DIR = $(DESTDIR)$(prefix)/src/$$PACKAGE_NAME-$$PACKAGE_VERSION
+dkms_install: INSTALL_BASE_DIR = $(DESTDIR)$(prefix)/src/liquidtux-$(PKGVER)
 
 dkms_install: dkms.conf
-	. ./dkms.conf && mkdir -p $(INSTALL_BASE_DIR)
-	. ./dkms.conf && $(INSTALL_DATA) dkms.conf Makefile Kbuild $(SOURCES) $(INSTALL_BASE_DIR)/
+	mkdir -p $(INSTALL_BASE_DIR)
+	$(INSTALL_DATA) dkms.conf Makefile Kbuild $(SOURCES) $(INSTALL_BASE_DIR)/


### PR DESCRIPTION
See https://github.com/liquidctl/liquidtux/actions/runs/3955424494/jobs/6773694899#step:6:7

I don't know dash (Ubuntu's /bin/sh) that well, so let's just force Makefile SHELL to be bash.