### PR TITLE
nzxt-kraken3: delay reading for X53 until first report is received; ensure proper concurrency for Z53

### DIFF
--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -722,12 +722,14 @@ static int kraken3_raw_event(struct hid_device *hdev, struct hid_report *report,
 	if (data[TEMP_SENSOR_START_OFFSET] == 0xff && data[TEMP_SENSOR_END_OFFSET] == 0xff) {
 		hid_err_once(hdev, "firmware or device is possibly damaged, not parsing reports\n");
 
-		/* Mark first X-series device report as received, even if faulty */
-		if (priv->kind == X53 && !completion_done(&priv->status_report_processed))
+		/*
+		 * Mark first X-series device report as received,
+		 * as well as all for Z-series, if faulty.
+		 */
+		if ((priv->kind == X53 && !completion_done(&priv->status_report_processed)) ||
+		    priv->kind == Z53)
 			complete_all(&priv->status_report_processed);
 
-		if (priv->kind == Z53)
-			complete(&priv->status_report_processed);
 		return 0;
 	}
 


### PR DESCRIPTION
This should resolve the issue of fancontrol possibly racing with the first report on X-series devices and reading an `-ENODATA`. Please do roast this approach if something's not right. `completion_done()` will always return true after a `complete_all()` call, that's how we know that the first report has been parsed and to skip doing that again.