### PR TITLE
nzxt-kraken3: Improve things noticed in #43, always return -ENODATA if device is faulty

### DIFF
--- a/docs/nzxt-kraken3.rst
+++ b/docs/nzxt-kraken3.rst
@@ -35,6 +35,10 @@ require complete curves to be sent for each change; they can lock up or discard
 the changes if they are too numerous at once. Suggestion is to set them while
 in an another mode, and then apply them by switching to curve.
 
+The devices can report if they are faulty. The driver supports that situation
+and will issue a warning. This can also happen when the USB cable is connected,
+but SATA power is not.
+
 The addressable RGB LEDs and LCD screen (only on Z-series models) are not
 supported in this driver, but can be controlled through existing userspace tools,
 such as `liquidctl`_.

--- a/docs/nzxt-kraken3.rst
+++ b/docs/nzxt-kraken3.rst
@@ -51,6 +51,14 @@ Usage Notes
 As these are USB HIDs, the driver can be loaded automatically by the kernel and
 supports hot swapping.
 
+Possible pwm_enable values are:
+
+====== ==========================================================================
+0      Set fan to 100%
+1      Direct PWM mode (applies value in corresponding PWM entry)
+2      Curve control mode (applies the temp-PWM duty curve based on coolant temp)
+====== ==========================================================================
+
 Sysfs entries
 -------------
 

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -834,8 +834,6 @@ static int __maybe_unused kraken3_reset_resume(struct hid_device *hdev)
 	return ret;
 }
 
-#ifdef CONFIG_DEBUG_FS
-
 static int firmware_version_show(struct seq_file *seqf, void *unused)
 {
 	struct kraken3_data *priv = seqf->private;
@@ -860,14 +858,6 @@ static void kraken3_debugfs_init(struct kraken3_data *priv)
 	priv->debugfs = debugfs_create_dir(name, NULL);
 	debugfs_create_file("firmware_version", 0444, priv->debugfs, priv, &firmware_version_fops);
 }
-
-#else
-
-static void kraken3_debugfs_init(struct kraken3_data *priv)
-{
-}
-
-#endif
 
 static int kraken3_probe(struct hid_device *hdev, const struct hid_device_id *id)
 {

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -720,8 +720,7 @@ static const struct hwmon_chip_info kraken3_chip_info = {
 	.info = kraken3_info,
 };
 
-static int kraken3_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data,
-			     int size)
+static int kraken3_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data, int size)
 {
 	struct kraken3_data *priv = hid_get_drvdata(hdev);
 	int i;
@@ -850,7 +849,7 @@ static void kraken3_debugfs_init(struct kraken3_data *priv)
 	char name[64];
 
 	if (!priv->firmware_version[0])
-		return; /* Nothing to display in debugfs */
+		return;		/* Nothing to display in debugfs */
 
 	scnprintf(name, sizeof(name), "%s_%s-%s", DRIVER_NAME, kraken3_device_names[priv->kind],
 		  dev_name(&priv->hdev->dev));

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -97,16 +97,7 @@ struct kraken3_data {
 	struct device *hwmon_dev;
 	struct dentry *debugfs;
 	struct mutex buffer_lock;	/* For locking access to buffer */
-	/* Used to ensure that only one reader requests a Z53 status report */
 	struct mutex z53_status_request_lock;
-	/*
-	 * For retaining returned error code in case of failure with
-	 * multiple readers present during status report refresh.
-	 */
-	int z53_status_request_ret;
-	/* For delaying multiple readers until a Z53 status report is received */
-	wait_queue_head_t z53_reader_wq;
-	bool z53_status_processed;
 	struct completion fw_version_processed;
 	struct completion status_report_processed;
 
@@ -897,7 +888,6 @@ static int kraken3_probe(struct hid_device *hdev, const struct hid_device_id *id
 
 	mutex_init(&priv->buffer_lock);
 	mutex_init(&priv->z53_status_request_lock);
-	init_waitqueue_head(&priv->z53_reader_wq);
 	init_completion(&priv->fw_version_processed);
 	init_completion(&priv->status_report_processed);
 

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -189,8 +189,7 @@ static int kraken3_write_expanded(struct kraken3_data *priv, const u8 *cmd, int 
 
 	mutex_lock(&priv->buffer_lock);
 
-	memset(priv->buffer, 0x00, MAX_REPORT_LENGTH);
-	memcpy(priv->buffer, cmd, cmd_length);
+	memcpy_and_pad(priv->buffer, MAX_REPORT_LENGTH, cmd, cmd_length, 0x00);
 	ret = hid_hw_output_report(priv->hdev, priv->buffer, MAX_REPORT_LENGTH);
 
 	mutex_unlock(&priv->buffer_lock);

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -743,7 +743,8 @@ static int kraken3_raw_event(struct hid_device *hdev, struct hid_report *report,
 		return 0;
 
 	if (data[TEMP_SENSOR_START_OFFSET] == 0xff && data[TEMP_SENSOR_END_OFFSET] == 0xff) {
-		hid_err_once(hdev, "firmware or device is possibly damaged, not parsing reports\n");
+		hid_err_once(hdev,
+			     "firmware or device is possibly damaged (is SATA power connected?), not parsing reports\n");
 
 		/*
 		 * Mark first X-series device report as received,

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -289,8 +289,8 @@ unlock_and_return:
 static int kraken3_read(struct device *dev, enum hwmon_sensor_types type, u32 attr, int channel,
 			long *val)
 {
-	int ret;
 	struct kraken3_data *priv = dev_get_drvdata(dev);
+	int ret;
 
 	if (time_after(jiffies, priv->updated + msecs_to_jiffies(STATUS_VALIDITY))) {
 		if (priv->kind == X53)
@@ -351,8 +351,8 @@ static int kraken3_read_string(struct device *dev, enum hwmon_sensor_types type,
 /* Writes custom curve to device */
 static int kraken3_write_curve(struct kraken3_data *priv, u8 *curve_array, int channel)
 {
-	int ret;
 	u8 fixed_duty_cmd[SET_CURVE_DUTY_CMD_LENGTH];
+	int ret;
 
 	/* Copy command header */
 	memcpy(fixed_duty_cmd, set_pump_duty_cmd_header, SET_CURVE_DUTY_CMD_HEADER_LENGTH);
@@ -369,8 +369,8 @@ static int kraken3_write_curve(struct kraken3_data *priv, u8 *curve_array, int c
 
 static int kraken3_write_fixed_duty(struct kraken3_data *priv, long val, int channel)
 {
-	int ret, percent_val, i;
 	u8 fixed_curve_points[CUSTOM_CURVE_POINTS];
+	int ret, percent_val, i;
 
 	percent_val = kraken3_pwm_to_percent(val, channel);
 	if (percent_val < 0)
@@ -399,8 +399,8 @@ static int kraken3_write_fixed_duty(struct kraken3_data *priv, long val, int cha
 static int kraken3_write(struct device *dev, enum hwmon_sensor_types type, u32 attr, int channel,
 			 long val)
 {
-	int ret;
 	struct kraken3_data *priv = dev_get_drvdata(dev);
+	int ret;
 
 	switch (type) {
 	case hwmon_pwm:
@@ -473,10 +473,10 @@ static int kraken3_write(struct device *dev, enum hwmon_sensor_types type, u32 a
 static ssize_t kraken3_fan_curve_pwm_store(struct device *dev, struct device_attribute *attr,
 					   const char *buf, size_t count)
 {
-	int ret;
-	long val;
 	struct sensor_device_attribute_2 *dev_attr = to_sensor_dev_attr_2(attr);
 	struct kraken3_data *priv = dev_get_drvdata(dev);
+	long val;
+	int ret;
 
 	if (kstrtol(buf, 10, &val) < 0)
 		return -EINVAL;
@@ -721,8 +721,8 @@ static const struct hwmon_chip_info kraken3_chip_info = {
 static int kraken3_raw_event(struct hid_device *hdev, struct hid_report *report, u8 *data,
 			     int size)
 {
-	int i;
 	struct kraken3_data *priv = hid_get_drvdata(hdev);
+	int i;
 
 	if (size < MIN_REPORT_LENGTH)
 		return 0;
@@ -783,8 +783,8 @@ static int kraken3_raw_event(struct hid_device *hdev, struct hid_report *report,
 
 static int kraken3_init_device(struct hid_device *hdev)
 {
-	int ret;
 	struct kraken3_data *priv = hid_get_drvdata(hdev);
+	int ret;
 
 	/* Set the polling interval */
 	ret = kraken3_write_expanded(priv, set_interval_cmd, SET_INTERVAL_CMD_LENGTH);
@@ -814,8 +814,8 @@ static int __maybe_unused kraken3_reset_resume(struct hid_device *hdev)
 
 static int firmware_version_show(struct seq_file *seqf, void *unused)
 {
-	int ret;
 	struct kraken3_data *priv = seqf->private;
+	int ret;
 
 	ret = kraken3_write_expanded(priv, get_fw_version_cmd, GET_FW_VERSION_CMD_LENGTH);
 	if (ret < 0)

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -321,7 +321,7 @@ static int kraken3_read(struct device *dev, enum hwmon_sensor_types type, u32 at
 			*val = priv->channel_info[channel].reported_duty;
 			break;
 		default:
-			break;
+			return -EOPNOTSUPP;
 		}
 		break;
 	default:
@@ -461,6 +461,8 @@ static int kraken3_write(struct device *dev, enum hwmon_sensor_types type, u32 a
 				break;
 			}
 			break;
+		default:
+			return -EOPNOTSUPP;
 		}
 		break;
 	default:

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -298,11 +298,11 @@ static int kraken3_read(struct device *dev, enum hwmon_sensor_types type, u32 at
 		else
 			ret = kraken3_read_z53(priv);
 
-		if (priv->is_device_faulty)
-			return -ENODATA;
-
 		if (ret < 0)
 			return ret;
+
+		if (priv->is_device_faulty)
+			return -ENODATA;
 	}
 
 	switch (type) {

--- a/nzxt-kraken3.c
+++ b/nzxt-kraken3.c
@@ -99,6 +99,11 @@ struct kraken3_data {
 	struct mutex buffer_lock;	/* For locking access to buffer */
 	struct mutex z53_status_request_lock;
 	struct completion fw_version_processed;
+	/*
+	 * For X53 devices, tracks whether an initial (one) sensor report was received to
+	 * make fancontrol not bail outright. For Z53 devices, whether a status report
+	 * was processed after requesting one.
+	 */
 	struct completion status_report_processed;
 
 	u8 *buffer;


### PR DESCRIPTION
This PR:
- improves the things @amezin commented on in #43
- adds a few comments to those parts
- formats the kraken3_raw_event() signature to be on one line
- improves the faultiness logic to return -ENODATA if the device reports it's faulty, for a cycle. Otherwise, stale data would be returned
- notes the faultiness reporting in the docs
- improves lots of things that Guenter complained about in the gigabyte_waterforce driver, that are directly applicable to this one