### PR TITLE
ci: Bump Ubuntu and kernel versions for CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         kconfig_debug_fs:
           - "-e CONFIG_DEBUG_FS"
           - "-d CONFIG_DEBUG_FS"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,8 +9,7 @@ jobs:
       matrix:
         kernel_version:
           - master
-          - v5.15
-          - v5.10
+          - v6.2
         kconfig_pm:
           - "-e CONFIG_PM"
           - "-d CONFIG_PM"

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   checkpatch:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - run: sudo apt-get update
       - run: sudo apt-get install -y codespell

--- a/.github/workflows/dkms.yml
+++ b/.github/workflows/dkms.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   dkms:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Just noticed that the kernel versions the CI uses are fairly old. Bump them up to current ones, including the Ubuntu version.

---

Shouldn't break anything, I hope? Or should I leave the 5.x ones in and only add these new ones?