### PR TITLE
vagrant: Add missing NZXT Kraken X53 and Z53 product IDs

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -11,6 +11,8 @@ USB_IDS = [
   { :vendor => "0x1e71", :product => "0x170e" },
   # nzxt-kraken3
   { :vendor => "0x1e71", :product => "0x2007" },
+  { :vendor => "0x1e71", :product => "0x2014" },
+  { :vendor => "0x1e71", :product => "0x3008" },
   # nzxt-smart2
   { :vendor => "0x1e71", :product => "0x2006" },
   { :vendor => "0x1e71", :product => "0x200d" },


### PR DESCRIPTION
This PR adds the missing IDs for NZXT Kraken X53 and Z53 to the Vagrant config.