### PR TITLE
Fix and update Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure("2") do |config|
     virtualbox.customize ["modifyvm", :id, "--usbxhci", "on"]
 
     # HACK: only create usb filters once, if vm doesn't exist yet
-    if not File.exists? File.join(".vagrant", "machines", "default", "virtualbox", "id")
+    if not File.exist? File.join(".vagrant", "machines", "default", "virtualbox", "id")
       USB_IDS.each_with_index do |usb_id, index|
         virtualbox.customize ["usbfilter", "add", index.to_s, "--target", :id, "--name", "dev-#{usb_id[:vendor]}-#{usb_id[:product]}", "--vendorid", usb_id[:vendor], "--productid", usb_id[:product]]
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -23,7 +23,7 @@ USB_IDS = [
 ]
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/37-cloud-base"
+  config.vm.box = "fedora/39-cloud-base"
 
   config.vm.provider "virtualbox" do |virtualbox, override|
     virtualbox.cpus = CPUS


### PR DESCRIPTION
Bump Fedora image version to 39 and fix an undefined method. (Seems like newer Ruby versions got rid of `exists?` in favor of `exist?`).