### PR TITLE
Update README since nzxt-kraken3 is now mainlined

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the current state of the drivers in regards to this process:
 | --- | --- | --- | --- |
 | NZXT Grid+ V3/Smart Device (V1) | `nzxt-grid3` | `smartdevice` | getting ready to submit | |
 | NZXT Kraken X42/X52/X62/X72 | `nzxt-kraken2` | `kraken2` | in Linux 5.13 ([patch][p-kraken2-v2]) |
-| NZXT Kraken X53/X63/X73 | `nzxt-kraken3` | `kraken3` | early work in progress |
+| NZXT Kraken X53/X63/X73, Z53/Z63/Z73 | `nzxt-kraken3` | `kraken3` | in Linux 6.9 ([patch][p-kraken3]) |
 | NZXT Smart Device V2/RGB & Fan Controller | `nzxt-smart2` | `nzxtsmart2` | in Linux 5.17 ([patch][p-smart2]) |
 
 This repository contains the latest state of each driver, including features
@@ -41,7 +41,7 @@ package.  After the package is installed, manually load the desired drivers.
 ```
 $ sudo modprobe nzxt-grid3              # NZXT Grid+ V3/Smart Device (V1)
 $ sudo modprobe nzxt-kraken2            # NZXT Kraken X42/X52/X62/X72
-$ sudo modprobe nzxt-kraken3            # NZXT Kraken X53/X63/X73
+$ sudo modprobe nzxt-kraken3            # NZXT Kraken X53/X63/X73, Z53/Z63/Z73
 $ sudo modprobe nzxt-smart2             # NZXT Smart Device V2/RGB & Fan Controller
 ```
 
@@ -72,7 +72,7 @@ built modules can then be loaded with `insmod`.
 $ make
 $ sudo insmod nzxt-grid3.ko             # NZXT Grid+ V3/Smart Device (V1)
 $ sudo insmod nzxt-kraken2.ko           # NZXT Kraken X42/X52/X62/X72
-$ sudo insmod nzxt-kraken3              # NZXT Kraken X53/X63/X73
+$ sudo insmod nzxt-kraken3              # NZXT Kraken X53/X63/X73, Z53/Z63/Z73
 $ sudo insmod nzxt-smart2               # NZXT Smart Device V2/RGB & Fan Controller
 ```
 
@@ -94,4 +94,5 @@ $ sudo make modules_install
 [liquidtux-dkms-git-aur]: https://aur.archlinux.org/packages/liquidtux-dkms-git/
 [lm-sensors]: https://github.com/lm-sensors/lm-sensors
 [p-kraken2-v2]: https://patchwork.kernel.org/project/linux-hwmon/patch/20210319045544.416138-1-jonas@protocubo.io/
+[p-kraken3]: https://patchwork.kernel.org/project/linux-hwmon/patch/20240129111932.368232-1-savicaleksa83@gmail.com/
 [p-smart2]: https://patchwork.kernel.org/project/linux-hwmon/patch/20211031033058.151014-1-mezin.alexander@gmail.com/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is the current state of the drivers in regards to this process:
 | NZXT Smart Device V2/RGB & Fan Controller | `nzxt-smart2` | `nzxtsmart2` | in Linux 5.17 ([patch][p-smart2]) |
 
 This repository contains the latest state of each driver, including features
-and bug fixes been worked on but no yet submitted upstream.
+and bug fixes that are not yet submitted upstream.
 
 _Note: other hwmon drivers exist in the mainline kernel for devices that
 liquidctl also supports: [`corsair-cpro`], [`corsair-psu`]._


### PR DESCRIPTION
Update README to note that nzxt-kraken3 will be available starting with Linux 6.9; note support for Kraken Z series devices.

While at it, fix flow of a sentence.

Closes #21, closes #7.