### PR TITLE
fixes asm/unaligned.h related compile errors

### DIFF
--- a/drivers/hwmon/nzxt-grid3.c
+++ b/drivers/hwmon/nzxt-grid3.c
@@ -33,7 +33,12 @@
  * Copyright 2019-2021  Jonas Malaco <jonas@protocubo.io>
  */
 
+#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
+
 #include <linux/bitops.h>
 #include <linux/errno.h>
 #include <linux/hid.h>

--- a/drivers/hwmon/nzxt-grid3.c
+++ b/drivers/hwmon/nzxt-grid3.c
@@ -35,10 +35,10 @@
 
 #include <generated/uapi/linux/version.h>
 
-#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
-#include <asm/unaligned.h>
-#else
+#if KERNEL_VERSION(6, 12, 0) <= LINUX_VERSION_CODE
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
 #endif
 
 #include <linux/bitops.h>

--- a/drivers/hwmon/nzxt-grid3.c
+++ b/drivers/hwmon/nzxt-grid3.c
@@ -33,10 +33,13 @@
  * Copyright 2019-2021  Jonas Malaco <jonas@protocubo.io>
  */
 
-#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
-#include <linux/unaligned.h>
-#else
+#include <generated/uapi/linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+// kernel before 6.12:
 #include <asm/unaligned.h>
+#else
+// kernel 6.12 onwards:
+#include <linux/unaligned.h>
 #endif
 
 #include <linux/bitops.h>

--- a/drivers/hwmon/nzxt-grid3.c
+++ b/drivers/hwmon/nzxt-grid3.c
@@ -34,11 +34,10 @@
  */
 
 #include <generated/uapi/linux/version.h>
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
-// kernel before 6.12:
+
+#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
 #include <asm/unaligned.h>
 #else
-// kernel 6.12 onwards:
 #include <linux/unaligned.h>
 #endif
 

--- a/drivers/hwmon/nzxt-kraken2.c
+++ b/drivers/hwmon/nzxt-kraken2.c
@@ -10,11 +10,10 @@
  */
 
 #include <generated/uapi/linux/version.h>
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
-// kernel before 6.12:
+
+#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
 #include <asm/unaligned.h>
 #else
-// kernel 6.12 onwards:
 #include <linux/unaligned.h>
 #endif
 

--- a/drivers/hwmon/nzxt-kraken2.c
+++ b/drivers/hwmon/nzxt-kraken2.c
@@ -11,10 +11,10 @@
 
 #include <generated/uapi/linux/version.h>
 
-#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
-#include <asm/unaligned.h>
-#else
+#if KERNEL_VERSION(6, 12, 0) <= LINUX_VERSION_CODE
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
 #endif
 
 #include <linux/hid.h>

--- a/drivers/hwmon/nzxt-kraken2.c
+++ b/drivers/hwmon/nzxt-kraken2.c
@@ -9,10 +9,13 @@
  * Copyright 2019-2021  Jonas Malaco <jonas@protocubo.io>
  */
 
-#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
-#include <linux/unaligned.h>
-#else
+#include <generated/uapi/linux/version.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+// kernel before 6.12:
 #include <asm/unaligned.h>
+#else
+// kernel 6.12 onwards:
+#include <linux/unaligned.h>
 #endif
 
 #include <linux/hid.h>

--- a/drivers/hwmon/nzxt-kraken2.c
+++ b/drivers/hwmon/nzxt-kraken2.c
@@ -9,7 +9,12 @@
  * Copyright 2019-2021  Jonas Malaco <jonas@protocubo.io>
  */
 
+#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
+
 #include <linux/hid.h>
 #include <linux/hwmon.h>
 #include <linux/jiffies.h>

--- a/drivers/hwmon/nzxt-kraken3.c
+++ b/drivers/hwmon/nzxt-kraken3.c
@@ -17,7 +17,12 @@
 #include <linux/mutex.h>
 #include <linux/spinlock.h>
 #include <linux/wait.h>
+
+#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
 
 #define USB_VENDOR_ID_NZXT		0x1e71
 #define USB_PRODUCT_ID_X53		0x2007

--- a/drivers/hwmon/nzxt-kraken3.c
+++ b/drivers/hwmon/nzxt-kraken3.c
@@ -8,6 +8,8 @@
  * Copyright 2022  Aleksa Savic <savicaleksa83@gmail.com>
  */
 
+#include <generated/uapi/linux/version.h>
+
 #include <linux/debugfs.h>
 #include <linux/hid.h>
 #include <linux/hwmon.h>
@@ -18,10 +20,12 @@
 #include <linux/spinlock.h>
 #include <linux/wait.h>
 
-#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
-#include <linux/unaligned.h>
-#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+// kernel before 6.12:
 #include <asm/unaligned.h>
+#else
+// kernel 6.12 onwards:
+#include <linux/unaligned.h>
 #endif
 
 #define USB_VENDOR_ID_NZXT		0x1e71

--- a/drivers/hwmon/nzxt-kraken3.c
+++ b/drivers/hwmon/nzxt-kraken3.c
@@ -20,11 +20,9 @@
 #include <linux/spinlock.h>
 #include <linux/wait.h>
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
-// kernel before 6.12:
+#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
 #include <asm/unaligned.h>
 #else
-// kernel 6.12 onwards:
 #include <linux/unaligned.h>
 #endif
 

--- a/drivers/hwmon/nzxt-kraken3.c
+++ b/drivers/hwmon/nzxt-kraken3.c
@@ -20,10 +20,10 @@
 #include <linux/spinlock.h>
 #include <linux/wait.h>
 
-#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
-#include <asm/unaligned.h>
-#else
+#if KERNEL_VERSION(6, 12, 0) <= LINUX_VERSION_CODE
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
 #endif
 
 #define USB_VENDOR_ID_NZXT		0x1e71

--- a/drivers/hwmon/nzxt-smart2.c
+++ b/drivers/hwmon/nzxt-smart2.c
@@ -9,10 +9,10 @@
 
 #include <linux/hid.h>
 #include <linux/hwmon.h>
-#if KERNEL_VERSION(5, 11, 0) > LINUX_VERSION_CODE
-#include <linux/kernel.h>
-#else
+#if KERNEL_VERSION(5, 11, 0) <= LINUX_VERSION_CODE
 #include <linux/math.h>
+#else
+#include <linux/kernel.h>
 #endif
 #include <linux/module.h>
 #include <linux/mutex.h>
@@ -21,10 +21,10 @@
 
 #include <asm/byteorder.h>
 
-#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
-#include <asm/unaligned.h>
-#else
+#if KERNEL_VERSION(6, 12, 0) <= LINUX_VERSION_CODE
 #include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
 #endif
 
 /*

--- a/drivers/hwmon/nzxt-smart2.c
+++ b/drivers/hwmon/nzxt-smart2.c
@@ -5,7 +5,7 @@
  * Copyright (c) 2021 Aleksandr Mezin
  */
 
-#include <linux/version.h>
+#include <generated/uapi/linux/version.h>
 
 #include <linux/hid.h>
 #include <linux/hwmon.h>
@@ -20,11 +20,12 @@
 #include <linux/wait.h>
 
 #include <asm/byteorder.h>
-
-#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
-#include <linux/unaligned.h>
-#else
+#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
+// kernel before 6.12:
 #include <asm/unaligned.h>
+#else
+// kernel 6.12 onwards:
+#include <linux/unaligned.h>
 #endif
 
 /*

--- a/drivers/hwmon/nzxt-smart2.c
+++ b/drivers/hwmon/nzxt-smart2.c
@@ -20,11 +20,10 @@
 #include <linux/wait.h>
 
 #include <asm/byteorder.h>
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 12, 0)
-// kernel before 6.12:
+
+#if KERNEL_VERSION(6, 12, 0) >= LINUX_VERSION_CODE
 #include <asm/unaligned.h>
 #else
-// kernel 6.12 onwards:
 #include <linux/unaligned.h>
 #endif
 

--- a/drivers/hwmon/nzxt-smart2.c
+++ b/drivers/hwmon/nzxt-smart2.c
@@ -20,7 +20,12 @@
 #include <linux/wait.h>
 
 #include <asm/byteorder.h>
+
+#if KERNEL_VERSION(6, 12, 0) > LINUX_VERSION_CODE
+#include <linux/unaligned.h>
+#else
 #include <asm/unaligned.h>
+#endif
 
 /*
  * The device has only 3 fan channels/connectors. But all HID reports have


### PR DESCRIPTION
This will fix the compilation errors shown in recent kernel sources caused by the relocation of asm/unaligned.h to its new location at linux/unaligned.h