### PR TITLE
nzxt-kraken3: add support for NZXT Kraken 2024 Elite (0x3012)

### DIFF
--- a/Documentation/hwmon/nzxt-kraken3.rst
+++ b/Documentation/hwmon/nzxt-kraken3.rst
@@ -13,6 +13,7 @@ Supported devices:
 * NZXT Kraken Z73
 * NZXT Kraken 2023
 * NZXT Kraken 2023 Elite
+* NZXT Kraken 2024 Elite
 
 Author: Jonas Malaco, Aleksa Savic
 
@@ -20,7 +21,8 @@ Description
 -----------
 
 This driver enables hardware monitoring support for NZXT Kraken X53/X63/X73,
-Z53/Z63/Z73 and Kraken 2023 (standard and Elite) all-in-one CPU liquid coolers.
+Z53/Z63/Z73, Kraken 2023 (standard and Elite) and Kraken 2024 Elite all-in-one
+CPU liquid coolers.
 All models expose liquid temperature and pump speed (in RPM), as well as PWM
 control (either as a fixed value or through a temp-PWM curve). The Z-series and
 Kraken 2023 models additionally expose the speed and duty of an optionally connected

--- a/drivers/hwmon/nzxt-kraken3.c
+++ b/drivers/hwmon/nzxt-kraken3.c
@@ -32,6 +32,7 @@
 #define USB_PRODUCT_ID_Z53		0x3008
 #define USB_PRODUCT_ID_KRAKEN2023	0x300E
 #define USB_PRODUCT_ID_KRAKEN2023_ELITE	0x300C
+#define USB_PRODUCT_ID_KRAKEN2024_ELITE	0x3012
 
 enum kinds { X53, Z53, KRAKEN2023 } __packed;
 enum pwm_enable { off, manual, curve } __packed;
@@ -934,6 +935,10 @@ static int kraken3_probe(struct hid_device *hdev, const struct hid_device_id *id
 		priv->kind = KRAKEN2023;
 		device_name = "kraken2023elite";
 		break;
+	case USB_PRODUCT_ID_KRAKEN2024_ELITE:
+		priv->kind = KRAKEN2023;
+		device_name = "kraken2024elite";
+		break;
 	default:
 		break;
 	}
@@ -998,6 +1003,7 @@ static const struct hid_device_id kraken3_table[] = {
 	{ HID_USB_DEVICE(USB_VENDOR_ID_NZXT, USB_PRODUCT_ID_Z53) },
 	{ HID_USB_DEVICE(USB_VENDOR_ID_NZXT, USB_PRODUCT_ID_KRAKEN2023) },
 	{ HID_USB_DEVICE(USB_VENDOR_ID_NZXT, USB_PRODUCT_ID_KRAKEN2023_ELITE) },
+	{ HID_USB_DEVICE(USB_VENDOR_ID_NZXT, USB_PRODUCT_ID_KRAKEN2024_ELITE) },
 	{ }
 };
 


### PR DESCRIPTION
Add USB product ID 0x3012 for the NZXT Kraken 2024 Elite (also known as Kraken Elite V2). This device uses the same protocol as the Kraken 2023 Elite and is already supported by liquidctl under the kraken3 driver family.

Tested on hardware: NZXT Kraken Elite V2 (1e71:3012), firmware 1.2.0. Sensors (liquid temperature, pump speed, fan speed) and PWM control confirmed working via sysfs/lm-sensors.